### PR TITLE
Add podspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,23 +46,22 @@ In order for us to provide optimal support, we would kindly ask you to submit an
 
 ### <a id="installation_ios"> iOS
 
+With CocoaPods, please see their [DOCS](https://guides.cocoapods.org/using/getting-started.html):
 
-1. Add the `appsFlyerFramework` to `podfile` and run `pod install`.
+1. Add the react-native-appsflyer pod to your `Podfile`:
 
+        pod 'react-native-smooch',
+             :path => '../node_modules/react-native-smooch'
 
-Example:
-     
-```
-use_frameworks!
-target 'demo' do
-  pod 'AppsFlyerFramework'
-end
-```
+  This assumes your `Podfile` is located in `ios` directory.
 
-  Don't use CocoaPods? Please see their [DOCS](https://guides.cocoapods.org/using/getting-started.html).
+  You must also have the React dependencies defined in the Podfile as described [here](http://facebook.github.io/react-native/releases/0.42/docs/troubleshooting.html#missing-libraries-for-react).
 
+2. Run `pod install` (inside `ios` directory).
 
-2. Create *bridge* between your application and `appsFlyerFramework`:
+Manually:
+
+1. Create *bridge* between your application and `appsFlyerFramework`:
   In XCode ➜ project navigator, right click `Libraries` ➜ `Add Files to [your project's name]`
   Go to `node_modules` ➜ `react-native-appsflyer` and add `RNAppsFlyer.xcodeproj`
    Build your project, It will generate `libRNAppsFlyer.a` file: 
@@ -71,7 +70,7 @@ end
   
      
 
-3. In your project **build phase** ➜ **Link binary with libraries** ➜ add `libRNAppsFlyer.a`. 
+2. In your project **build phase** ➜ **Link binary with libraries** ➜ add `libRNAppsFlyer.a`. 
 Run your project (`Cmd+R`) or through CLI run: `react-native run-ios`
 
 ##### **Breaking Changes for react-native >= 0.40.0:**

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ With CocoaPods, please see their [DOCS](https://guides.cocoapods.org/using/getti
 
   This assumes your `Podfile` is located in `ios` directory.
 
-  You must also have the React dependencies defined in the Podfile as described [here](http://facebook.github.io/react-native/releases/0.42/docs/troubleshooting.html#missing-libraries-for-react).
+  You must also have the React dependencies defined in the Podfile as described [here](https://facebook.github.io/react-native/docs/next/troubleshooting.html#missing-libraries-for-react).
 
 2. Run `pod install` (inside `ios` directory).
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ With CocoaPods, please see their [DOCS](https://guides.cocoapods.org/using/getti
 
 1. Add the react-native-appsflyer pod to your `Podfile`:
 
-        pod 'react-native-smooch',
-             :path => '../node_modules/react-native-smooch'
+        pod 'react-native-appsflyer',
+             :path => '../node_modules/react-native-appsflyer'
 
   This assumes your `Podfile` is located in `ios` directory.
 

--- a/react-native-appsflyer.podspec
+++ b/react-native-appsflyer.podspec
@@ -1,0 +1,17 @@
+require 'json'
+pkg = JSON.parse(File.read("package.json"))
+
+Pod::Spec.new do |s|
+  s.name         = pkg["name"]
+  s.version      = pkg["version"]
+  s.summary      = pkg["description"]
+  s.requires_arc = true
+  s.license      = pkg["license"]
+  s.homepage     = pkg["homepage"]
+  s.author       = pkg["author"]
+  s.source       = { :git => pkg["repository"]["url"] }
+  s.source_files = 'ios/**/*.{h,m}'
+  s.platform     = :ios, "8.0"
+  s.dependency 'React/Core'
+  s.dependency 'AppsFlyerFramework', '~> 4.6.3'
+end

--- a/react-native-appsflyer.podspec
+++ b/react-native-appsflyer.podspec
@@ -13,5 +13,5 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/**/*.{h,m}'
   s.platform     = :ios, "8.0"
   s.dependency 'React/Core'
-  s.dependency 'AppsFlyerFramework', '~> 4.6.3'
+  s.dependency 'AppsFlyerFramework', '~> 4.8.1'
 end


### PR DESCRIPTION
Makes the iOS integration a bit easier and gives you control of the AppsFlyerFramework dependency version.

Changed a bit in the README to make the install procedure a bit clearer I hope, have a look and change if needed.