### PR TITLE
Remove unused createJSModules calls

### DIFF
--- a/android/src/main/java/com/appsflyer/reactnative/RNAppsFlyerPackage.java
+++ b/android/src/main/java/com/appsflyer/reactnative/RNAppsFlyerPackage.java
@@ -26,11 +26,6 @@ public class RNAppsFlyerPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-      return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
       return Collections.emptyList();
     }


### PR DESCRIPTION
Breaking change since React Native 0.47