### PR TITLE
Correct order of arguments for trackEvent

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ appsFlyer.setCustomerUserId(userId,
 ---
 
 
-##### <a id="trackEvent"> **`appsFlyer.trackEvent(eventName, eventValues, errorC, successC): void`**
+##### <a id="trackEvent"> **`appsFlyer.trackEvent(eventName, eventValues, successC, errorC): void`**
 
 
 - These in-app events help you track how loyal users discover your app, and attribute them to specific 
@@ -242,7 +242,7 @@ const eventValues = {
   "af_revenue": "2"
 };
 
-appsFlyer.trackEvent(eventName, eventValues, errorC, successC) => {
+appsFlyer.trackEvent(eventName, eventValues, successC, errorC) => {
   (result) => {
     //...
   },


### PR DESCRIPTION
The ```successC``` and ```errorC``` were listed in the wrong order in the README. It should be this: https://github.com/AppsFlyerSDK/react-native-appsflyer/blob/6e18c698c1c5d6f9dec84700b3c46732fc637df1/index.js#L29-L31

/review @af-fess