### PR TITLE
fixed RNAppsFlyerPackage.java to be compatible with react 16.0.0

### DIFF
--- a/android/src/main/java/com/appsflyer/reactnative/RNAppsFlyerPackage.java
+++ b/android/src/main/java/com/appsflyer/reactnative/RNAppsFlyerPackage.java
@@ -21,6 +21,11 @@ public class RNAppsFlyerPackage implements ReactPackage {
     }
 
     @Override
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+      return Collections.emptyList();
+    }
+
+    @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
       return Arrays.<NativeModule>asList(new RNAppsFlyerModule(reactContext, this.application));
     }


### PR DESCRIPTION
Fixed RNAppsFlyerPackage.java to be compatible with:

- "react": "16.0.0-alpha.12"
- "react-native": "^0.45.1"
