### PR TITLE
Make project compatible with use_framework! option on Cocoapods

### DIFF
--- a/ios/RNAppsFlyer.h
+++ b/ios/RNAppsFlyer.h
@@ -9,7 +9,7 @@
 
 
 
-@interface RNAppsFlyer : NSObject <RCTBridgeModule,AppsFlyerTrackerDelegate>
+@interface RNAppsFlyer : NSObject <RCTBridgeModule>
 
 @end
 

--- a/ios/RNAppsFlyer.m
+++ b/ios/RNAppsFlyer.m
@@ -1,6 +1,9 @@
-
-#import "AppsFlyerTracker.h"
 #import "RNAppsFlyer.h"
+#import <AppsFlyerLib/AppsFlyerTracker.h>
+
+@interface RNAppsFlyer() <AppsFlyerTrackerDelegate>
+
+@end
 
 @implementation RNAppsFlyer
 

--- a/react-native-appsflyer.podspec
+++ b/react-native-appsflyer.podspec
@@ -13,4 +13,5 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/**/*.{h,m}'
   s.platform     = :ios, "8.0"
   s.dependency 'AppsFlyerFramework', '~> 4.8.4'
+  s.dependency 'React'
 end


### PR DESCRIPTION
The project file was wrong built, it just contained 2 files, now I have added the missing files as well.

Thanks.

Note: Not sure if you need to publish a new `npm` version.