### PR TITLE
Moves dependency on https://maven.google.com to build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,6 +20,7 @@ android {
 
 repositories {
     mavenCentral()
+    maven { url "https://maven.google.com" }
 }
 
 dependencies {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-appsflyer",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "React Native Appsflyer plugin",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This change adds the `maven { url "https://maven.google.com" }` dependency to build.gradle

Adding this dependency on the android application level sometimes causes conflicts with other dependencies in the project ([Leanplum Android SDK](https://github.com/Leanplum/Leanplum-Android-SDK) in my case). 