### PR TITLE
Re-add section to README about adding Google install referrer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,27 @@ ext {
 ```
 
 
+AppsFlyer SDK uses Google Install referrer.
+
+Open the `build.gradle` file for your application.
+Make sure that the repositories section includes a maven section with the "https://maven.google.com" endpoint. For example:
+
+```gradle
+allprojects {
+    repositories {
+        mavenLocal()
+        jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
+        maven {
+            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+            url "$rootDir/../node_modules/react-native/android"
+        }
+    }
+}
+```
+
 
 Build project so you should get following dependency (see an Image):
 
@@ -286,7 +307,7 @@ appsFlyer.stopTracking(true,
 
 ##### <a id="setCollectIMEI"> **`appsFlyer.setCollectIMEI = (isCollect, successCallback): void`**
 
-By default, IMEI and Android ID are not collected by the SDK if the OS version is higher than KitKat (4.4) and the device contains Google Play Services (on SDK versions 4.8.8 and below the specific app needed GPS). 
+By default, IMEI and Android ID are not collected by the SDK if the OS version is higher than KitKat (4.4) and the device contains Google Play Services (on SDK versions 4.8.8 and below the specific app needed GPS).
 
 | parameter   | type                        | description |
 | ----------- |-----------------------------|--------------|
@@ -305,7 +326,7 @@ appsFlyer.setCollectIMEI(false,
 
 ##### <a id="setCollectAndroidID"> **`appsFlyer.setCollectAndroidID = (isCollect, successCallback): void`**
 
-By default, IMEI and Android ID are not collected by the SDK if the OS version is higher than KitKat (4.4) and the device contains Google Play Services (on SDK versions 4.8.8 and below the specific app needed GPS). 
+By default, IMEI and Android ID are not collected by the SDK if the OS version is higher than KitKat (4.4) and the device contains Google Play Services (on SDK versions 4.8.8 and below the specific app needed GPS).
 
 | parameter   | type                        | description |
 | ----------- |-----------------------------|--------------|


### PR DESCRIPTION
This reverts commit c8a17b777a4554dfaeeac81b7221c22d51f79f56.

This step, previously described in your README, is required in order for your Android project to build successfully after installing the `react-native-appsflyer` (>= v.1.1.13)

(Otherwise attempted builds result in error `Could not find com.android.installreferrer:installreferrer:1.0...`)