### PR TITLE
Update paths in .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,1 @@
-/demo
-/DemoPod2
+/examples


### PR DESCRIPTION
The examples were moved to the `examples` directory in 11a5967e327f118b3d9fae0e25874e7f44c398ab.