### PR TITLE
Make react-native-appsflyer work with use_frameworks! in cocoapods

### DIFF
--- a/react-native-appsflyer.podspec
+++ b/react-native-appsflyer.podspec
@@ -2,16 +2,17 @@ require 'json'
 pkg = JSON.parse(File.read("package.json"))
 
 Pod::Spec.new do |s|
-  s.name         = pkg["name"]
-  s.version      = pkg["version"]
-  s.summary      = pkg["description"]
-  s.requires_arc = true
-  s.license      = pkg["license"]
-  s.homepage     = pkg["homepage"]
-  s.author       = pkg["author"]
-  s.source       = { :git => pkg["repository"]["url"] }
-  s.source_files = 'ios/**/*.{h,m}'
-  s.platform     = :ios, "8.0"
+  s.name             = pkg["name"]
+  s.version          = pkg["version"]
+  s.summary          = pkg["description"]
+  s.requires_arc     = true
+  s.license          = pkg["license"]
+  s.homepage         = pkg["homepage"]
+  s.author           = pkg["author"]
+  s.source           = { :git => pkg["repository"]["url"] }
+  s.source_files     = 'ios/**/*.{h,m}'
+  s.platform         = :ios, "8.0"
+  s.static_framework = true
   s.dependency 'AppsFlyerFramework', '~> 4.8.12'
   s.dependency 'React'
 end


### PR DESCRIPTION
Adding `s.static_framework = true` will avoid the transitive dependencies error that occurs if you set `use_frameworks!` in your `Podfile`.

```
[!] The 'Pods-AppName' target has transitive dependencies that include static binaries: (your-App-Name-path/Pods/AppsFlyerFramework/AppsFlyerLib.framework)
```