### PR TITLE
fix: added missing email crypt type in iOS

### DIFF
--- a/Docs/API.md
+++ b/Docs/API.md
@@ -376,7 +376,7 @@ Set the user emails and encrypt them.
 
 | option          | type  | description   |
 | --------------  | ----  |------------- |
-| emailsCryptType | int   | none - 0 (default), SHA1 - 1, MD5 - 2 |
+| emailsCryptType | int   | none - 0 (default), SHA1 - 1, MD5 - 2, SHA256 - 3 |
 | emails          | array | comma separated list of emails |
 
 

--- a/ios/RNAppsFlyer.m
+++ b/ios/RNAppsFlyer.m
@@ -119,6 +119,9 @@ RCT_EXPORT_METHOD(setUserEmails: (NSDictionary*)options
                 case EmailCryptTypeMD5:
                     emailsCryptType = EmailCryptTypeMD5;
                     break;
+                case EmailCryptTypeSHA256:
+                    emailsCryptType = EmailCryptTypeSHA256;
+                    break;
                 default:
                     emailsCryptType = EmailCryptTypeNone;
             }


### PR DESCRIPTION
Android can process `SHA256` but not in iOS
so, added missing `EmailCryptTypeSHA256` type to [iOS](https://github.com/AppsFlyerSDK/AppsFlyerFramework/blob/dbdea499361ead78f0fe6fecfd819ae8c3a2c41f/iOS/AppsFlyerLib.framework/Versions/A/Headers/AppsFlyerTracker.h#L147)


[TODO: add SHA256 to email crypt type enum in #110]